### PR TITLE
ランキング計算をキャッシュする

### DIFF
--- a/app/Http/Controllers/CircleController.php
+++ b/app/Http/Controllers/CircleController.php
@@ -23,7 +23,7 @@ class CircleController extends Controller
             array_push($rankedCircles, Circle::getNameAndFreetextBy($circleId));
         }
 
-        return response()->view('circles.ranking', compact('rankedCircles'));
+        return response()->view('circles.ranking', compact('rankedCircles', 'circleIds'));
     }
 
     /**
@@ -55,7 +55,10 @@ class CircleController extends Controller
      */
     public function show(string $id): Response
     {
-        $circle = Circle::where('id', $id)->first();
+        $circle = Circle::find($id);
+
+        // 閲覧ログを記録する
+        ViewLog::create(['circle_id' => $id]);
 
         return response()->view('circles.show', compact('circle'));
     }

--- a/app/Models/ViewLog.php
+++ b/app/Models/ViewLog.php
@@ -5,13 +5,17 @@ namespace App\Models;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class ViewLog extends Model
 {
+    protected $fillable = ['circle_id'];
+
     use HasFactory;
 
-    public function circle() {
+    public function circle()
+    {
         return $this->belongsTo('App\Models\Circle');  // logが属するcircleは一つ（なのでメソッド名は単数形）
     }
 
@@ -21,18 +25,24 @@ class ViewLog extends Model
      * @param int $circlesLimit - ランキングの結果、上位`$circlesLimit`件のサークルidを取得する
      * @return array `circle_id`が格納された配列
      */
-    public static function RankingOfCircleByLogCount(int $daysAgo, int $circlesLimit) {
+    public static function RankingOfCircleByLogCount(int $daysAgo, int $circlesLimit)
+    {
         $dateSince = Carbon::now()->subDays($daysAgo);
 
-        $circleIds = self::where('created_at', '>=', $dateSince)
-            ->groupBy('circle_id')
-            ->select('circle_id', DB::raw('count(*) as log_count'))
-            ->orderByDesc('log_count')
-            ->take($circlesLimit)
-            ->get()
-            ->pluck('circle_id')
-            ->toArray();
-        
+        // キャッシュ時間は 5分 とする
+        $cacheSeconds = 1 * 60 * 5;  // 秒
+
+        $circleIds = Cache::remember('circle_ranking', $cacheSeconds, function () use ($dateSince, $circlesLimit) {
+            return self::where('created_at', '>=', $dateSince)
+                ->groupBy('circle_id')
+                ->select('circle_id', DB::raw('count(*) as log_count'))
+                ->orderByDesc('log_count')
+                ->take($circlesLimit)
+                ->get()
+                ->pluck('circle_id')
+                ->toArray();
+        });
+
         return $circleIds;
     }
 }

--- a/resources/views/circles/ranking.blade.php
+++ b/resources/views/circles/ranking.blade.php
@@ -1,6 +1,7 @@
 <div>circles.ranking</div>
 
-@foreach ($rankedCircles as $circle)
+@foreach ($rankedCircles as $i => $circle)
+    <p>{{$circleIds[$i]}}</p>
     <div>{{ $circle->name }}</div>
     <div>{{ $circle->free_text }}</div>
     <div>-------</div>


### PR DESCRIPTION
fix: #7

# やったこと

- ランキング計算を行うメソッドに対して、Laravelの提供するファイルキャッシュファサードを適用した